### PR TITLE
feat: adiciona componentes de textField singleline e multiline com có…

### DIFF
--- a/PetLover/PetLover/Views/Components/Inputs/TextFields/MultilineTextfield.swift
+++ b/PetLover/PetLover/Views/Components/Inputs/TextFields/MultilineTextfield.swift
@@ -1,0 +1,76 @@
+//
+//  MultilineTextfield.swift
+//  PetLover
+//
+//  Created by Izadora Montenegro on 27/03/25.
+//
+
+import SwiftUI
+
+struct MultilineTextField: View {
+    @Binding var text: String
+    @Binding var buttonPressed: Bool
+    
+    var placeholder: String
+    var minHeight: CGFloat = 94
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            ZStack(alignment: .topLeading) {
+                if text.isEmpty {
+                    Text(placeholder)
+                        .font(.custom("Darker Grotesque", size: 14).weight(.bold))
+                        .foregroundColor(Color.AppColors.secondary70DarkBlue)
+                        .padding(.top, 12)
+                        .padding(.leading, 8)
+                }
+                
+                TextEditor(text: $text)
+                    .font(.custom("Darker Grotesque", size: 14).weight(.bold))
+                    .foregroundColor(.black)
+                    .padding(.leading, 4)
+                    .background(Color.clear)
+                    .scrollContentBackground(.hidden)
+                    .onSubmit {
+                        text += "\n"
+                    }
+                    .frame(minHeight: minHeight)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(lineWidth: 1)
+                    .foregroundColor(buttonPressed && text.isEmpty ? .AppColors.helperErrorRed : .black)
+            )
+            .padding(.horizontal)
+            
+            if buttonPressed && text.isEmpty {
+                Text("Campo obrigatório. Preencha antes de continuar.")
+                    .font(.custom("Darker Grotesque", size: 14).weight(.bold))
+                    .foregroundColor(Color.AppColors.helperErrorRed)
+                    .padding(.leading)
+            }
+        }
+    }
+}
+
+#Preview {
+    @Previewable @State var text: String = ""
+    @Previewable @State var buttonPressed: Bool = false
+    
+    VStack {
+        MultilineTextField(text: $text, buttonPressed: $buttonPressed, placeholder: "Fique à vontade para adicionar informações sobre seu pet, como alergias, remédios em uso, etc...")
+        
+        Button(action: {
+            if text.isEmpty {
+                buttonPressed = true
+            } else {
+                buttonPressed = false
+            }
+        }, label: {
+            Text("Botão de continuar")
+        })
+        .padding(.top)
+        
+    }
+}

--- a/PetLover/PetLover/Views/Components/Inputs/TextFields/SinglelineTextfield.swift
+++ b/PetLover/PetLover/Views/Components/Inputs/TextFields/SinglelineTextfield.swift
@@ -1,0 +1,68 @@
+//
+//  SinglelineTextfield.swift
+//  PetLover
+//
+//  Created by Izadora Montenegro on 27/03/25.
+//
+
+import SwiftUI
+
+struct SinglelineTextField: View {
+    @Binding var text: String
+    @Binding var buttonPressed: Bool
+    
+    var label: String
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            ZStack(alignment: .leading) {
+                if text.isEmpty {
+                    Text(label)
+                        .font(.custom("Darker Grotesque", size: 14).weight(.bold))
+                        .foregroundColor(Color.AppColors.secondary70DarkBlue)
+                        .padding(.leading, 8)
+                }
+                
+                TextField("", text: $text)
+                    .font(.custom("Darker Grotesque", size: 14).weight(.bold))
+                    .foregroundColor(Color.AppColors.secondary70DarkBlue)
+                    .padding(.vertical, 14)
+                    .padding(.leading, 10)
+            }
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(lineWidth: 1)
+                    .foregroundColor(buttonPressed && text.isEmpty ? .AppColors.helperErrorRed : .black)
+            )
+            .padding(.horizontal)
+            
+            if buttonPressed && text.isEmpty {
+                Text("Campo obrigatório. Preencha antes de continuar.")
+                    .font(.custom("Darker Grotesque", size: 14).weight(.bold))
+                    .foregroundColor(Color.AppColors.helperErrorRed)
+                    .padding(.leading)
+            }
+        }
+    }
+}
+
+#Preview {
+    @Previewable @State var text: String = ""
+    @Previewable @State var buttonPressed: Bool = false
+    
+    VStack {
+        SinglelineTextField(text: $text, buttonPressed: $buttonPressed, label: "Insira seu nome")
+        
+        Button(action: {
+            if text.isEmpty {
+                buttonPressed = true
+            } else {
+                buttonPressed = false
+            }
+        }, label: {
+            Text("Botão de continuar")
+        })
+        .padding(.top)
+        
+    }
+}


### PR DESCRIPTION
Multiline:
<img width="404" alt="Captura de Tela 2025-03-27 às 19 09 09" src="https://github.com/user-attachments/assets/82d9a6ef-5be7-4f29-9ff1-fcc26bca8f48" />
<img width="433" alt="Captura de Tela 2025-03-27 às 19 09 29" src="https://github.com/user-attachments/assets/129d62e8-56b6-4282-94d1-9cfe0e2af4b2" />
<img width="397" alt="Captura de Tela 2025-03-27 às 19 09 35" src="https://github.com/user-attachments/assets/f2ea0198-bb50-4ef2-bdde-880e9f5f08b0" />

Singleline:
<img width="359" alt="Captura de Tela 2025-03-27 às 19 09 45" src="https://github.com/user-attachments/assets/7f527d7c-a71f-4a9a-a443-032106d2deaa" />
<img width="415" alt="Captura de Tela 2025-03-27 às 19 09 52" src="https://github.com/user-attachments/assets/6733f877-2c20-4b42-96aa-0ece5518702e" />
<img width="403" alt="Captura de Tela 2025-03-27 às 19 09 56" src="https://github.com/user-attachments/assets/38f195e4-51b7-4ba2-9213-4d13437d9fcf" />
