### PR TITLE
feat: adiciona componente de header para o formulário de criação do pet

### DIFF
--- a/PetLover/PetLover/Views/MyPets/CreatePet/Components/PetFormHeader.swift
+++ b/PetLover/PetLover/Views/MyPets/CreatePet/Components/PetFormHeader.swift
@@ -1,0 +1,27 @@
+//
+//  PetFormHeader.swift
+//  PetLover
+//
+//  Created by Izadora Montenegro on 22/04/25.
+//
+
+import SwiftUI
+
+struct PetFormHeader: View {
+    @State var title: String
+    @State var text: String
+    @State var totalPages: Int
+    @State var currentPage: Int
+    var body: some View {
+        VStack(alignment: .center, spacing: 8) {
+            Text(title)
+                .appFontDarkerGrotesque(darkness: .SemiBold, size: 24)
+            Text(text)
+                .appFontDarkerGrotesque(darkness: .Regular, size: 17)
+                .multilineTextAlignment(.center)
+            PageProgressBar(totalPages: totalPages, currentPage: currentPage)
+                .padding(.horizontal, 70)
+                .padding(.top, 8)
+        }
+    }
+}

--- a/PetLover/PetLover/Views/MyPets/CreatePet/PetBasicInfoView.swift
+++ b/PetLover/PetLover/Views/MyPets/CreatePet/PetBasicInfoView.swift
@@ -21,15 +21,7 @@ struct PetBasicInfoView: View {
     var body: some View {
         ScrollView {
             VStack(spacing: 24) {
-                VStack(spacing: 8) {
-                    Text("Informações básicas")
-                        .appFontDarkerGrotesque(darkness: .SemiBold, size: 24)
-                    Text("Insira as informações primárias do seu pet!")
-                        .appFontDarkerGrotesque(darkness: .Regular, size: 17)
-                    PageProgressBar(totalPages: 4, currentPage: 1)
-                        .padding(.horizontal, 70)
-                        .padding(.top, 8)
-                }
+                PetFormHeader(title: "Informações básicas", text: "Insira as informações primárias do seu pet!", totalPages: 4, currentPage: 1)
                 
                 VStack(alignment: .leading, spacing: 24) {
                     VStack(alignment: .leading, spacing: 8) {
@@ -266,4 +258,3 @@ struct FluxoAdicionarPet: View {
         }
     }
 }
-

--- a/PetLover/PetLover/Views/MyPets/CreatePet/PetDocumentsView.swift
+++ b/PetLover/PetLover/Views/MyPets/CreatePet/PetDocumentsView.swift
@@ -31,28 +31,19 @@ struct PetDocumentsView: View {
         ZStack(alignment: .bottom) {
             ScrollView {
                 VStack(spacing: 16) {
-                    VStack(spacing: 8) {
-                        Text("Documentos")
-                            .appFontDarkerGrotesque(darkness: .SemiBold, size: 24)
-                        Text("Falta pouco! Adicione aqui informações a respeito do peso, alergias, e tudo o que achar relevante.")
-                            .appFontDarkerGrotesque(darkness: .Regular, size: 17)
-                            .multilineTextAlignment(.center)
-                            .padding(.horizontal, 26)
-                        Text("Clique no card para selecionar o arquivo")
-                            .appFontDarkerGrotesque(darkness: .Regular, size: 17)
-                            .padding(.top)
-                        PageProgressBar(totalPages: 4, currentPage: 4)
-                            .padding(.horizontal, 70)
-                            .padding(.top, 8)
-                    }
+                    PetFormHeader(title: "Documentos", text: """
+Falta pouco! Adicione aqui informações a respeito do peso, alergias, e tudo o que achar relevante.
 
+Clique no card para selecionar o arquivo
+""", totalPages: 4, currentPage: 4)
+                    
                     VStack(alignment: .leading, spacing: 8) {
                         Text("Título")
                             .appFontDarkerGrotesque(darkness: .ExtraBold, size: 19)
                             .padding(.leading)
                         SinglelineTextField(text: $tempTitle, buttonPressed: $buttonPressed, label: "Qual o título desse documento?")
                     }
-
+                    
                     if petCreationViewModel.petDocuments.isEmpty {
                         SelectFileButton(tempURL: tempURL) {
                             isImporterPresented = true
@@ -66,7 +57,7 @@ struct PetDocumentsView: View {
                         }
                         .padding(.horizontal)
                     }
-
+                    
                     if petCreationViewModel.petDocuments.isEmpty {
                         SaveButton(tempTitle: tempTitle, tempURL: tempURL) {
                             let newDoc = PetDocument(title: tempTitle, fileURL: tempURL!)
@@ -90,12 +81,12 @@ struct PetDocumentsView: View {
                             }
                         )
                     }
-
+                    
                     Spacer()
                 }
                 .padding(.top, 40)
             }
-
+            
             SaveOrSelectButton(
                 tempTitle: tempTitle,
                 tempURL: tempURL,

--- a/PetLover/PetLover/Views/MyPets/CreatePet/PetMedicalConditionsView.swift
+++ b/PetLover/PetLover/Views/MyPets/CreatePet/PetMedicalConditionsView.swift
@@ -20,17 +20,8 @@ struct PetMedicalConditionsView: View {
     var body: some View {
         ScrollView {
             VStack(spacing: 24) {
-                VStack(spacing: 8) {
-                    Text("Condições Médicas")
-                        .appFontDarkerGrotesque(darkness: .SemiBold, size: 24)
-                    Text("Falta pouco! Adicione aqui informações a respeito do peso, alergias, e tudo o que achar relevante.")
-                        .appFontDarkerGrotesque(darkness: .Regular, size: 17)
-                        .multilineTextAlignment(.center)
-                        .padding(.horizontal, 30)
-                    PageProgressBar(totalPages: 4, currentPage: 3)
-                        .padding(.horizontal, 70)
-                        .padding(.top, 8)
-                }
+                PetFormHeader(title: "Condições Médicas", text: "Falta pouco! Adicione aqui informações a respeito do peso, alergias, e tudo o que achar relevante.", totalPages: 4, currentPage: 3)
+              
                 VStack(alignment: .leading, spacing: 8) {
                     Text("Castração")
                         .appFontDarkerGrotesque(darkness: .ExtraBold, size: 19)

--- a/PetLover/PetLover/Views/MyPets/CreatePet/PetProfileView.swift
+++ b/PetLover/PetLover/Views/MyPets/CreatePet/PetProfileView.swift
@@ -19,17 +19,7 @@ struct PetProfileView: View {
 
     var body: some View {
         VStack(spacing: 24) {
-            VStack(spacing: 8) {
-                Text("Perfil do Pet")
-                    .appFontDarkerGrotesque(darkness: .SemiBold, size: 24)
-                
-                Text("Escolha uma foto (.png, .jpeg) para o perfil do seu pet.")
-                    .appFontDarkerGrotesque(darkness: .Regular, size: 17)
-                
-                PageProgressBar(totalPages: 4, currentPage: 2)
-                    .padding(.horizontal, 70)
-                    .padding(.top, 8)
-            }
+            PetFormHeader(title: "Perfil do Pet", text: "Escolha uma foto (.png, .jpeg) para o perfil do seu pet.", totalPages: 4, currentPage: 2)
 
             if let imageData = petCreationViewModel.photo,
                let uiImage = UIImage(data: imageData) {


### PR DESCRIPTION
Componentizei o header das páginas do formulário de adicionar pet. Apenas para deixar o código menos poluído.
<img width="251" alt="Captura de Tela 2025-04-22 às 18 46 12" src="https://github.com/user-attachments/assets/413e7eaa-b463-4e68-a28b-3c1f84790e89" />
